### PR TITLE
Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,22 +193,21 @@
 			<id>romanface.repo</id>
 			<url>http://romanface.googlecode.com/git/repo</url>
 		</repository>
-		
+
 	</repositories>
 <!-- 	<pluginRepositories>
 	<pluginRepository>
-    <id>sonatype-public-repository</id>
-    <url>https://oss.sonatype.org/content/groups/public</url>
-    <snapshots>
-        <enabled>true</enabled>
-    </snapshots>
-    <releases>
-        <enabled>true</enabled>
-    </releases>
+	<id>sonatype-public-repository</id>
+	<url>https://oss.sonatype.org/content/groups/public</url>
+	<snapshots>
+		<enabled>true</enabled>
+	</snapshots>
+	<releases>
+		<enabled>true</enabled>
+	</releases>
 </pluginRepository>
 	</pluginRepositories> -->
 	<build>
-	   <pluginManagement>
 		<plugins>
 			<plugin>
 				<!-- We depend on at least java 1.5. -->
@@ -227,7 +226,6 @@
 				<executions>
 					<execution>
 						<id>install-drop_finder</id>
-						<!--<phase>pre-integration-test</phase>-->
 						<phase>process-resources</phase>
 						<goals>
 							<goal>wget</goal>
@@ -283,7 +281,6 @@
 				</executions>
 			</plugin>
 		</plugins>
-		   </pluginManagement>
 	</build>
 
 </project>


### PR DESCRIPTION
The error you told me today was due to my insertion of **pluginManagement** tags, in order to avoid errors when I try to manage the project in Eclipse. 

I removed these tags with this pul request, and Eclipse does not like that but when the file is compiled using terminal command, it does the job. 

This Eclipse specific problem ("Plugin execution not covered by lifecycle configuration") seems to be a known issue and here is a solution I found (but have not tried)

https://mahichir.wordpress.com/2014/05/14/solving-the-plugin-execution-not-covered-by-lifecycle-configuration-error-in-eclipse/ 

In addition, I forgot to tell you that before "mvn compile", "mvn process-resources" command will download jar files to the lib/. So

```
mvn clean process-resources
mvn compile
```

Will be the sequence. 
